### PR TITLE
fix: rate limiter test burst protection false positive

### DIFF
--- a/hq/src/rate-limiter.test.ts
+++ b/hq/src/rate-limiter.test.ts
@@ -49,8 +49,15 @@ describe('RateLimiter', () => {
     it('should allow requests within limit', async () => {
       const identifier = 'test-user';
       
+      // Use a limiter with higher burst limit for this test
+      const testLimiter = new RateLimiter(env, {
+        windowMs: 60000, 
+        maxRequests: 5,
+        maxBurst: 10, // Higher burst limit to allow rapid testing
+      });
+      
       for (let i = 0; i < 5; i++) {
-        const result = await limiter.checkLimit(identifier);
+        const result = await testLimiter.checkLimit(identifier);
         expect(result.allowed).toBe(true);
         expect(result.remaining).toBe(4 - i);
       }


### PR DESCRIPTION
## Summary
Fixes the failing rate limiter test by adjusting the burst limit configuration for rapid test execution.

## Problem
- Test was failing with `expected false to be true` on line 54
- All 5 test requests executed within same millisecond
- Triggered burst protection (maxBurst = 3), blocking the 4th request

## Solution  
- Use dedicated test limiter with maxBurst = 10 for the `should allow requests within limit` test
- Allows rapid automated testing while preserving rate limit validation
- Other tests retain original burst limits to test protection mechanisms

## Changes
- Modified MockKVNamespace to remove KVNamespace interface constraint
- Increased burst limit from 3 to 10 for specific test case
- Type annotation changed to `any` for mock flexibility

## Testing
✅ All 25 tests passing
✅ Rate limiting logic validated
✅ Burst protection still tested in dedicated test case

## Related Issues
- Fixes CI test failures after #2 (rate limiting implementation)
- No production impact - test configuration only